### PR TITLE
design: replace purple palette with fumadocs neutral color system

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,24 +4,28 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
-    --card: 0 0% 98%;
-    --card-foreground: 240 10% 3.9%;
-    --border: 240 5.9% 90%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
+    --background: 0 0% 96%;
+    --foreground: 0 0% 3.9%;
+    --card: 0 0% 94.7%;
+    --card-foreground: 0 0% 3.9%;
+    --border: 0 0% 80%;
+    --muted: 0 0% 96.1%;
+    --muted-foreground: 0 0% 45.1%;
+    --primary: 0 0% 9%;
+    --primary-foreground: 0 0% 98%;
     --grid-color: 0, 0, 0;
   }
 
   .dark {
-    --background: 240 10% 3.9%;
+    --background: 0 0% 2%;
     --foreground: 0 0% 98%;
-    --card: 240 10% 5.5%;
+    --card: 0 0% 4%;
     --card-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --muted: 240 3.7% 12%;
-    --muted-foreground: 240 5% 64.9%;
+    --border: 0 0% 14%;
+    --muted: 0 0% 8%;
+    --muted-foreground: 0 0% 60%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 0 0% 9%;
     --grid-color: 255, 255, 255;
   }
 
@@ -41,31 +45,41 @@
   }
 
   ::selection {
-    @apply bg-violet-500/20 text-violet-900 dark:text-violet-100;
+    background: hsl(0 0% 20% / 0.15);
+  }
+
+  .dark ::selection {
+    background: hsl(0 0% 80% / 0.2);
   }
 
   ::-webkit-scrollbar { width: 5px; }
   ::-webkit-scrollbar-track { @apply bg-transparent; }
-  ::-webkit-scrollbar-thumb { @apply bg-border rounded-full; }
+  ::-webkit-scrollbar-thumb { background: hsl(var(--border)); border-radius: 9999px; }
 }
 
 @layer utilities {
   .gradient-text {
-    @apply bg-gradient-to-r from-violet-500 via-purple-500 to-cyan-500 bg-clip-text text-transparent;
+    @apply bg-gradient-to-r from-neutral-900 to-neutral-600 dark:from-neutral-100 dark:to-neutral-400 bg-clip-text text-transparent;
   }
 
   .grid-bg {
     background-image:
-      linear-gradient(to right, rgb(var(--grid-color) / 0.05) 1px, transparent 1px),
-      linear-gradient(to bottom, rgb(var(--grid-color) / 0.05) 1px, transparent 1px);
+      linear-gradient(to right, rgb(var(--grid-color) / 0.04) 1px, transparent 1px),
+      linear-gradient(to bottom, rgb(var(--grid-color) / 0.04) 1px, transparent 1px);
     background-size: 40px 40px;
   }
 
   .card-base {
-    @apply rounded-xl border border-border bg-card transition-all duration-200;
+    @apply rounded-xl border bg-card transition-all duration-200;
+    border-color: hsl(var(--border));
   }
 
   .card-hover {
-    @apply card-base hover:border-violet-500/40 hover:shadow-lg hover:shadow-violet-500/5;
+    @apply card-base;
+  }
+
+  .card-hover:hover {
+    border-color: hsl(var(--border));
+    background-color: hsl(var(--muted));
   }
 }

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -9,8 +9,8 @@ const techStack = [
 ];
 
 const fadeUp = {
-  hidden: { opacity: 0, y: 20 },
-  show: { opacity: 1, y: 0 },
+  hidden: { opacity: 0, y: 16 },
+  show:   { opacity: 1, y: 0 },
 };
 
 export function About() {
@@ -27,7 +27,7 @@ export function About() {
           {/* Left — text */}
           <div className="space-y-6">
             <motion.div variants={fadeUp} className="space-y-2">
-              <p className="font-mono text-xs font-semibold uppercase tracking-widest text-violet-500">
+              <p className="font-mono text-xs font-semibold uppercase tracking-widest text-muted-foreground">
                 About me
               </p>
               <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
@@ -37,35 +37,26 @@ export function About() {
               </h2>
             </motion.div>
 
-            <motion.p
-              variants={fadeUp}
-              className="text-base leading-relaxed text-muted-foreground"
-            >
+            <motion.p variants={fadeUp} className="text-base leading-relaxed text-muted-foreground">
               Hi! I&apos;m Jiasheng Lu — a passionate full stack developer based
               in Calgary, Canada. I graduated from SAIT with an Award of
               Excellence and have been building web applications for 4+ years.
             </motion.p>
 
-            <motion.p
-              variants={fadeUp}
-              className="text-base leading-relaxed text-muted-foreground"
-            >
-              I care deeply about clean code, great user experiences, and
-              solving real problems. Whether it&apos;s a snappy React UI or a
-              robust Node.js API, I bring the same level of attention to every
-              layer of the stack.
+            <motion.p variants={fadeUp} className="text-base leading-relaxed text-muted-foreground">
+              I care deeply about clean code, great user experiences, and solving
+              real problems. Whether it&apos;s a snappy React UI or a robust
+              Node.js API, I bring the same attention to every layer of the stack.
             </motion.p>
 
             {/* Tech stack */}
             <motion.div variants={fadeUp} className="space-y-3">
-              <p className="text-sm font-medium text-foreground">
-                Primary stack
-              </p>
-              <div className="flex flex-wrap gap-2">
+              <p className="text-sm font-medium text-foreground">Primary stack</p>
+              <div className="flex flex-wrap gap-1.5">
                 {techStack.map((tech) => (
                   <span
                     key={tech}
-                    className="rounded-md border border-border bg-muted px-3 py-1 font-mono text-xs text-muted-foreground"
+                    className="rounded-md border border-border bg-muted px-2.5 py-1 font-mono text-xs text-muted-foreground"
                   >
                     {tech}
                   </span>
@@ -74,16 +65,16 @@ export function About() {
             </motion.div>
           </div>
 
-          {/* Right — stats grid */}
-          <div className="grid grid-cols-2 gap-4">
+          {/* Right — stats */}
+          <div className="grid grid-cols-2 gap-3">
             {stats.map((stat, i) => (
               <motion.div
                 key={stat.label}
                 variants={fadeUp}
                 transition={{ delay: i * 0.05 }}
-                className="card-hover rounded-xl border border-border bg-card p-6"
+                className="card-base rounded-xl p-6"
               >
-                <p className="text-3xl font-bold gradient-text">{stat.value}</p>
+                <p className="text-3xl font-bold text-foreground">{stat.value}</p>
                 <p className="mt-1 text-sm text-muted-foreground">{stat.label}</p>
               </motion.div>
             ))}
@@ -91,10 +82,10 @@ export function About() {
             {/* SAIT badge */}
             <motion.div
               variants={fadeUp}
-              className="col-span-2 card-base rounded-xl border border-violet-500/20 bg-violet-500/5 p-5"
+              className="col-span-2 card-base rounded-xl p-5"
             >
               <div className="flex items-center gap-3">
-                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-violet-500/15 text-violet-400">
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-base">
                   🎓
                 </div>
                 <div>

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -12,16 +12,16 @@ const iconMap = {
 
 export function Contact() {
   return (
-    <section id="contact" className="py-24 bg-muted/30">
+    <section id="contact" className="py-24 bg-muted/40">
       <div className="mx-auto max-w-6xl px-6">
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
+          initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           className="mx-auto max-w-2xl text-center space-y-8"
         >
           <div className="space-y-3">
-            <p className="font-mono text-xs font-semibold uppercase tracking-widest text-violet-500">
+            <p className="font-mono text-xs font-semibold uppercase tracking-widest text-muted-foreground">
               Get in touch
             </p>
             <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
@@ -35,22 +35,22 @@ export function Contact() {
             </p>
           </div>
 
-          {/* Primary CTAs */}
+          {/* CTAs */}
           <div className="flex flex-wrap items-center justify-center gap-3">
             <a
               href={`mailto:${email}`}
-              className="inline-flex items-center gap-2 rounded-lg bg-violet-600 px-6 py-3 text-sm font-semibold text-white transition-all hover:bg-violet-700 hover:shadow-lg hover:shadow-violet-500/20"
+              className="inline-flex items-center gap-2 rounded-md border border-border bg-primary px-6 py-2.5 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
             >
               Say Hello
-              <ArrowRight size={15} />
+              <ArrowRight size={14} />
             </a>
             <a
               href={resumeUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-6 py-3 text-sm font-semibold text-foreground transition-all hover:border-violet-500/40 hover:bg-muted"
+              className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-6 py-2.5 text-sm font-semibold text-foreground transition-colors hover:bg-muted"
             >
-              <Download size={15} />
+              <Download size={14} />
               Download Resume
             </a>
           </div>
@@ -67,16 +67,12 @@ export function Contact() {
                   rel="noopener noreferrer"
                   className="card-hover group flex items-center gap-3 rounded-xl border border-border bg-card p-4 text-left"
                 >
-                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground transition-colors group-hover:border-violet-500/40 group-hover:bg-violet-500/10 group-hover:text-violet-500">
-                    {Icon && <Icon size={16} />}
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-foreground transition-colors group-hover:bg-card">
+                    {Icon && <Icon size={15} />}
                   </div>
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-foreground">
-                      {link.platform}
-                    </p>
-                    <p className="truncate font-mono text-xs text-muted-foreground">
-                      {link.handle}
-                    </p>
+                    <p className="text-sm font-medium text-foreground">{link.platform}</p>
+                    <p className="truncate font-mono text-xs text-muted-foreground">{link.handle}</p>
                   </div>
                 </a>
               );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -8,28 +8,25 @@ const iconMap = {
 };
 
 const navLinks = [
-  { label: "About", href: "#about" },
+  { label: "About",    href: "#about" },
   { label: "Projects", href: "#projects" },
-  { label: "Skills", href: "#skills" },
-  { label: "Contact", href: "#contact" },
+  { label: "Skills",   href: "#skills" },
+  { label: "Contact",  href: "#contact" },
 ];
 
 export function Footer() {
   const year = new Date().getFullYear();
 
   return (
-    <footer className="border-t border-border bg-card/50">
+    <footer className="border-t border-border bg-card/40">
       <div className="mx-auto max-w-6xl px-6 py-10">
         <div className="flex flex-col items-center gap-6 sm:flex-row sm:justify-between">
           {/* Logo */}
-          <a
-            href="#"
-            className="flex items-center gap-2 font-mono text-sm font-semibold text-foreground"
-          >
-            <span className="flex h-7 w-7 items-center justify-center rounded-md bg-violet-600 text-white text-xs font-bold">
+          <a href="#" className="flex items-center gap-2 font-mono text-sm font-semibold text-foreground">
+            <span className="flex h-6 w-6 items-center justify-center rounded border border-border bg-foreground text-background text-[10px] font-bold">
               JL
             </span>
-            <span className="gradient-text">Jiasheng Lu</span>
+            Jiasheng Lu
           </a>
 
           {/* Nav */}
@@ -46,7 +43,7 @@ export function Footer() {
           </nav>
 
           {/* Socials */}
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-0.5">
             {socialLinks.map((link) => {
               const Icon = iconMap[link.icon as keyof typeof iconMap];
               return (
@@ -58,7 +55,7 @@ export function Footer() {
                   aria-label={link.platform}
                   className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground hover:bg-muted"
                 >
-                  {Icon && <Icon size={15} />}
+                  {Icon && <Icon size={14} />}
                 </a>
               );
             })}
@@ -67,9 +64,7 @@ export function Footer() {
 
         <div className="mt-8 border-t border-border pt-6 text-center">
           <p className="text-xs text-muted-foreground">
-            © {year} Jiasheng Lu. Built with{" "}
-            <span className="text-violet-500">Next.js</span> &amp;{" "}
-            <span className="text-cyan-500">Tailwind CSS</span>.
+            © {year} Jiasheng Lu. Built with Next.js &amp; Tailwind CSS.
           </p>
         </div>
       </div>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -13,77 +13,73 @@ const roles = [
 ];
 
 const codeLines = [
-  { text: "const jiasheng = {", indent: 0 },
-  { text: '  role: "Full Stack Developer",', indent: 0 },
-  { text: '  location: "Calgary, Canada",', indent: 0 },
-  { text: "  loves: [", indent: 0 },
-  { text: '    "clean code",', indent: 0 },
-  { text: '    "great UX",', indent: 0 },
-  { text: '    "solving hard problems",', indent: 0 },
-  { text: "  ],", indent: 0 },
-  { text: "  available: true,", indent: 0 },
-  { text: "}", indent: 0 },
+  { key: "open",    raw: "const jiasheng = {" },
+  { key: "role",    raw: '  role: "Full Stack Developer",' },
+  { key: "loc",     raw: '  location: "Calgary, Canada",' },
+  { key: "arr",     raw: "  loves: [" },
+  { key: "l1",      raw: '    "clean code",' },
+  { key: "l2",      raw: '    "great UX",' },
+  { key: "l3",      raw: '    "hard problems",' },
+  { key: "close2",  raw: "  ]," },
+  { key: "avail",   raw: "  available: true," },
+  { key: "close",   raw: "}" },
 ];
 
 const socialLinks = [
-  { icon: Github, href: "https://github.com/jonsnowljs", label: "GitHub" },
-  {
-    icon: Linkedin,
-    href: "https://www.linkedin.com/in/jiashenglujob",
-    label: "LinkedIn",
-  },
-  { icon: Mail, href: "mailto:jiasheng.lu@edu.sait.ca", label: "Email" },
+  { icon: Github,   href: "https://github.com/jonsnowljs",              label: "GitHub" },
+  { icon: Linkedin, href: "https://www.linkedin.com/in/jiashenglujob", label: "LinkedIn" },
+  { icon: Mail,     href: "mailto:jiasheng.lu@edu.sait.ca",            label: "Email" },
 ];
 
 export function Hero() {
   const [roleIndex, setRoleIndex] = useState(0);
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      setRoleIndex((i) => (i + 1) % roles.length);
-    }, 2800);
-    return () => clearInterval(interval);
+    const t = setInterval(() => setRoleIndex((i) => (i + 1) % roles.length), 2800);
+    return () => clearInterval(t);
   }, []);
 
   return (
     <section className="relative flex min-h-screen items-center overflow-hidden">
-      {/* Grid background */}
+      {/* Subtle grid */}
       <div className="absolute inset-0 grid-bg" />
 
-      {/* Radial glow */}
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_60%_50%_at_50%_-10%,theme(colors.violet.500/15),transparent)]" />
+      {/* Radial fade at top */}
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_70%_40%_at_50%_0%,hsl(var(--muted)/60%),transparent)]" />
 
-      <div className="relative mx-auto w-full max-w-6xl px-6 pt-24 pb-16">
+      <div className="relative mx-auto w-full max-w-6xl px-6 pt-24 pb-20">
         <div className="grid gap-12 lg:grid-cols-2 lg:items-center">
+
           {/* Left — copy */}
           <motion.div
-            initial={{ opacity: 0, y: 24 }}
+            initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
+            transition={{ duration: 0.5 }}
             className="flex flex-col gap-6"
           >
-            {/* Badge */}
-            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-violet-500/30 bg-violet-500/10 px-3 py-1 text-xs font-medium text-violet-400">
-              <span className="h-1.5 w-1.5 rounded-full bg-violet-400 animate-pulse" />
+            {/* Status badge */}
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-border bg-muted px-3 py-1 text-xs font-medium text-muted-foreground">
+              <span className="h-1.5 w-1.5 rounded-full bg-foreground/60 animate-pulse" />
               Available for work
             </span>
 
             {/* Heading */}
             <div className="space-y-2">
-              <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+              <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl leading-[1.1]">
                 Hi, I&apos;m{" "}
                 <span className="gradient-text">Jiasheng Lu</span>
               </h1>
-              <div className="flex items-center gap-2 text-xl text-muted-foreground sm:text-2xl">
-                <motion.span
+              <div className="h-8 overflow-hidden">
+                <motion.p
                   key={roleIndex}
-                  initial={{ opacity: 0, y: 8 }}
+                  initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -8 }}
+                  exit={{ opacity: 0 }}
                   transition={{ duration: 0.3 }}
+                  className="text-xl text-muted-foreground"
                 >
                   {roles[roleIndex]}
-                </motion.span>
+                </motion.p>
               </div>
             </div>
 
@@ -98,24 +94,24 @@ export function Hero() {
             <div className="flex flex-wrap items-center gap-3">
               <a
                 href="#projects"
-                className="inline-flex items-center gap-2 rounded-lg bg-violet-600 px-5 py-2.5 text-sm font-semibold text-white transition-all hover:bg-violet-700 hover:shadow-lg hover:shadow-violet-500/20"
+                className="inline-flex items-center gap-2 rounded-md border border-border bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
               >
                 View My Work
-                <ArrowRight size={15} />
+                <ArrowRight size={14} />
               </a>
               <a
                 href={resumeUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-5 py-2.5 text-sm font-semibold text-foreground transition-all hover:border-violet-500/40 hover:bg-muted"
+                className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-5 py-2.5 text-sm font-semibold text-foreground transition-colors hover:bg-muted"
               >
-                <Download size={15} />
+                <Download size={14} />
                 Resume
               </a>
             </div>
 
             {/* Social */}
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-0.5">
               {socialLinks.map(({ icon: Icon, href, label }) => (
                 <a
                   key={label}
@@ -123,9 +119,9 @@ export function Hero() {
                   target={href.startsWith("mailto") ? undefined : "_blank"}
                   rel="noopener noreferrer"
                   aria-label={label}
-                  className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground hover:bg-muted"
+                  className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground hover:bg-muted"
                 >
-                  <Icon size={18} />
+                  <Icon size={16} />
                 </a>
               ))}
             </div>
@@ -133,62 +129,35 @@ export function Hero() {
 
           {/* Right — code card */}
           <motion.div
-            initial={{ opacity: 0, x: 24 }}
+            initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
-            transition={{ duration: 0.6, delay: 0.2 }}
+            transition={{ duration: 0.5, delay: 0.15 }}
             className="hidden lg:block"
           >
-            <div className="rounded-xl border border-border bg-card overflow-hidden shadow-2xl shadow-black/20">
+            <div className="overflow-hidden rounded-xl border border-border bg-card shadow-xl shadow-black/10 dark:shadow-black/40">
               {/* Window chrome */}
-              <div className="flex items-center gap-1.5 border-b border-border bg-muted/50 px-4 py-3">
-                <span className="h-2.5 w-2.5 rounded-full bg-red-500/70" />
-                <span className="h-2.5 w-2.5 rounded-full bg-yellow-500/70" />
-                <span className="h-2.5 w-2.5 rounded-full bg-green-500/70" />
+              <div className="flex items-center gap-1.5 border-b border-border bg-muted/60 px-4 py-3">
+                <span className="h-2.5 w-2.5 rounded-full bg-border" />
+                <span className="h-2.5 w-2.5 rounded-full bg-border" />
+                <span className="h-2.5 w-2.5 rounded-full bg-border" />
                 <span className="ml-3 font-mono text-xs text-muted-foreground">
                   jiasheng.ts
                 </span>
               </div>
-              {/* Code */}
+              {/* Code body */}
               <div className="p-5 font-mono text-sm leading-7">
                 {codeLines.map((line, i) => (
                   <motion.div
-                    key={i}
-                    initial={{ opacity: 0, x: -8 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    transition={{ delay: 0.4 + i * 0.07 }}
+                    key={line.key}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transition={{ delay: 0.3 + i * 0.07 }}
                     className="flex"
                   >
-                    <span className="w-8 shrink-0 select-none text-right text-muted-foreground/40 text-xs leading-7 mr-4">
+                    <span className="w-7 shrink-0 select-none text-right text-xs text-muted-foreground/40 leading-7 mr-4">
                       {i + 1}
                     </span>
-                    <span>
-                      {line.text.startsWith("const") ? (
-                        <>
-                          <span className="text-violet-400">const </span>
-                          <span className="text-cyan-400">jiasheng</span>
-                          <span className="text-foreground"> = {"{"}</span>
-                        </>
-                      ) : line.text === "}" ? (
-                        <span className="text-foreground">{"}"}</span>
-                      ) : line.text.includes('"') ? (
-                        (() => {
-                          const m = line.text.match(/^(\s*)([\w]+)(:)(\s*)(.+)$/);
-                          if (m) {
-                            return (
-                              <>
-                                <span className="text-foreground">{m[1]}</span>
-                                <span className="text-violet-300">{m[2]}</span>
-                                <span className="text-foreground">{m[3]}{m[4]}</span>
-                                <span className="text-green-400">{m[5]}</span>
-                              </>
-                            );
-                          }
-                          return <span className="text-green-400">{line.text}</span>;
-                        })()
-                      ) : (
-                        <span className="text-foreground">{line.text}</span>
-                      )}
-                    </span>
+                    <span className="text-foreground/80">{line.raw}</span>
                   </motion.div>
                 ))}
               </div>
@@ -201,12 +170,14 @@ export function Hero() {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ delay: 1.2 }}
-          className="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1"
+          className="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1.5"
         >
-          <span className="text-xs text-muted-foreground">scroll</span>
+          <span className="font-mono text-[10px] text-muted-foreground/60 tracking-widest uppercase">
+            scroll
+          </span>
           <motion.div
-            animate={{ y: [0, 6, 0] }}
-            transition={{ repeat: Infinity, duration: 1.5 }}
+            animate={{ y: [0, 5, 0] }}
+            transition={{ repeat: Infinity, duration: 1.6 }}
             className="h-4 w-px bg-border"
           />
         </motion.div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -34,20 +34,20 @@ export function Navbar() {
           : "bg-transparent"
       )}
     >
-      <nav className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+      <nav className="mx-auto flex h-14 max-w-6xl items-center justify-between px-6">
         {/* Logo */}
         <a
           href="#"
           className="flex items-center gap-2 font-mono text-sm font-semibold text-foreground"
         >
-          <span className="flex h-7 w-7 items-center justify-center rounded-md bg-violet-600 text-white text-xs font-bold">
+          <span className="flex h-6 w-6 items-center justify-center rounded border border-border bg-foreground text-background text-[10px] font-bold">
             JL
           </span>
-          <span className="hidden sm:inline gradient-text">jiasheng.lu</span>
+          <span className="hidden sm:inline text-foreground">jiasheng.lu</span>
         </a>
 
         {/* Desktop links */}
-        <ul className="hidden md:flex items-center gap-1">
+        <ul className="hidden md:flex items-center gap-0.5">
           {navLinks.map((link) => (
             <li key={link.href}>
               <a
@@ -62,32 +62,29 @@ export function Navbar() {
 
         {/* Right controls */}
         <div className="flex items-center gap-2">
-          {/* Theme toggle */}
           {mounted && (
             <button
               onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
               className="flex h-8 w-8 items-center justify-center rounded-md border border-border bg-card text-muted-foreground transition-colors hover:text-foreground hover:bg-muted"
               aria-label="Toggle theme"
             >
-              {theme === "dark" ? <Sun size={15} /> : <Moon size={15} />}
+              {theme === "dark" ? <Sun size={14} /> : <Moon size={14} />}
             </button>
           )}
 
-          {/* Hire me */}
           <a
             href="mailto:jiasheng.lu@edu.sait.ca"
-            className="hidden md:inline-flex items-center gap-1.5 rounded-md bg-violet-600 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-violet-700"
+            className="hidden md:inline-flex items-center gap-1.5 rounded-md border border-border bg-primary px-4 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:opacity-90"
           >
             Hire Me
           </a>
 
-          {/* Mobile menu button */}
           <button
             onClick={() => setOpen(!open)}
             className="md:hidden flex h-8 w-8 items-center justify-center rounded-md border border-border text-muted-foreground hover:text-foreground"
             aria-label="Toggle menu"
           >
-            {open ? <X size={16} /> : <Menu size={16} />}
+            {open ? <X size={15} /> : <Menu size={15} />}
           </button>
         </div>
       </nav>
@@ -107,7 +104,7 @@ export function Navbar() {
           ))}
           <a
             href="mailto:jiasheng.lu@edu.sait.ca"
-            className="mt-2 inline-flex items-center justify-center rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white"
+            className="mt-2 inline-flex items-center justify-center rounded-md border border-border bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
           >
             Hire Me
           </a>

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -9,29 +9,25 @@ import { clsx } from "clsx";
 const categories = ["All", "Full Stack", "Frontend"];
 
 const fadeUp = {
-  hidden: { opacity: 0, y: 20 },
-  show: { opacity: 1, y: 0 },
+  hidden: { opacity: 0, y: 16 },
+  show:   { opacity: 1, y: 0 },
 };
 
 export function Projects() {
   const [active, setActive] = useState("All");
-
-  const filtered =
-    active === "All"
-      ? projects
-      : projects.filter((p) => p.category === active);
+  const filtered = active === "All" ? projects : projects.filter((p) => p.category === active);
 
   return (
-    <section id="projects" className="py-24 bg-muted/30">
+    <section id="projects" className="py-24 bg-muted/40">
       <div className="mx-auto max-w-6xl px-6">
         {/* Header */}
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
+          initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           className="mb-12 space-y-4"
         >
-          <p className="font-mono text-xs font-semibold uppercase tracking-widest text-violet-500">
+          <p className="font-mono text-xs font-semibold uppercase tracking-widest text-muted-foreground">
             Work
           </p>
           <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
@@ -47,7 +43,7 @@ export function Projects() {
                   className={clsx(
                     "rounded-md px-3 py-1 text-sm font-medium transition-all",
                     active === cat
-                      ? "bg-violet-600 text-white shadow-sm"
+                      ? "bg-primary text-primary-foreground shadow-sm"
                       : "text-muted-foreground hover:text-foreground"
                   )}
                 >
@@ -60,11 +56,11 @@ export function Projects() {
 
         {/* Grid */}
         <motion.div
-          variants={{ show: { transition: { staggerChildren: 0.1 } } }}
+          variants={{ show: { transition: { staggerChildren: 0.08 } } }}
           initial="hidden"
           whileInView="show"
           viewport={{ once: true, margin: "-60px" }}
-          className="grid gap-5 sm:grid-cols-2"
+          className="grid gap-4 sm:grid-cols-2"
         >
           {filtered.map((project) => (
             <motion.article
@@ -73,18 +69,16 @@ export function Projects() {
               className="card-hover group relative flex flex-col overflow-hidden rounded-xl border border-border bg-card"
             >
               {project.featured && (
-                <span className="absolute right-4 top-4 z-10 rounded-full border border-violet-500/30 bg-violet-500/10 px-2.5 py-0.5 text-[10px] font-semibold text-violet-400">
+                <span className="absolute right-4 top-4 z-10 rounded-full border border-border bg-muted px-2.5 py-0.5 text-[10px] font-medium text-muted-foreground">
                   Featured
                 </span>
               )}
 
               <div className="flex flex-1 flex-col gap-4 p-6">
                 <div className="space-y-1">
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-xs text-muted-foreground">
-                      {project.category} · {project.year}
-                    </span>
-                  </div>
+                  <span className="font-mono text-xs text-muted-foreground">
+                    {project.category} · {project.year}
+                  </span>
                   <h3 className="text-lg font-semibold text-foreground">
                     {project.title}
                   </h3>
@@ -107,7 +101,7 @@ export function Projects() {
                 </div>
 
                 {/* Links */}
-                <div className="flex items-center gap-3 border-t border-border pt-4">
+                <div className="flex items-center gap-4 border-t border-border pt-4">
                   <a
                     href={project.github}
                     target="_blank"
@@ -121,7 +115,7 @@ export function Projects() {
                     href={project.demo}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-xs font-medium text-violet-500 transition-colors hover:text-violet-400"
+                    className="inline-flex items-center gap-1.5 text-xs font-medium text-foreground transition-colors hover:text-muted-foreground"
                   >
                     <ExternalLink size={13} />
                     Live Demo

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -6,8 +6,8 @@ import { skillCategories } from "@/data/skills";
 import { clsx } from "clsx";
 
 const fadeUp = {
-  hidden: { opacity: 0, y: 16 },
-  show: { opacity: 1, y: 0 },
+  hidden: { opacity: 0, y: 12 },
+  show:   { opacity: 1, y: 0 },
 };
 
 export function Skills() {
@@ -19,12 +19,12 @@ export function Skills() {
       <div className="mx-auto max-w-6xl px-6">
         {/* Header */}
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
+          initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           className="mb-12 space-y-2"
         >
-          <p className="font-mono text-xs font-semibold uppercase tracking-widest text-violet-500">
+          <p className="font-mono text-xs font-semibold uppercase tracking-widest text-muted-foreground">
             Expertise
           </p>
           <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
@@ -32,7 +32,7 @@ export function Skills() {
           </h2>
         </motion.div>
 
-        <div className="grid gap-8 lg:grid-cols-[220px_1fr]">
+        <div className="grid gap-8 lg:grid-cols-[200px_1fr]">
           {/* Category sidebar */}
           <nav className="flex gap-1 lg:flex-col">
             {skillCategories.map((cat) => (
@@ -40,9 +40,9 @@ export function Skills() {
                 key={cat.id}
                 onClick={() => setActive(cat.id)}
                 className={clsx(
-                  "rounded-lg px-4 py-2.5 text-left text-sm font-medium transition-all",
+                  "rounded-lg px-4 py-2 text-left text-sm font-medium transition-all",
                   active === cat.id
-                    ? "bg-violet-600 text-white shadow-sm shadow-violet-500/20"
+                    ? "bg-primary text-primary-foreground"
                     : "text-muted-foreground hover:text-foreground hover:bg-muted"
                 )}
               >
@@ -63,16 +63,14 @@ export function Skills() {
               <motion.div key={skill.name} variants={fadeUp} className="space-y-1.5">
                 <div className="flex items-center justify-between text-sm">
                   <span className="font-medium text-foreground">{skill.name}</span>
-                  <span className="font-mono text-xs text-muted-foreground">
-                    {skill.level}%
-                  </span>
+                  <span className="font-mono text-xs text-muted-foreground">{skill.level}%</span>
                 </div>
-                <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
                   <motion.div
                     initial={{ width: 0 }}
                     animate={{ width: `${skill.level}%` }}
-                    transition={{ duration: 0.7, ease: "easeOut" }}
-                    className="h-full rounded-full bg-gradient-to-r from-violet-500 to-cyan-500"
+                    transition={{ duration: 0.6, ease: "easeOut" }}
+                    className="h-full rounded-full bg-foreground/80"
                   />
                 </div>
               </motion.div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,6 +17,10 @@ const config: Config = {
         border: "hsl(var(--border))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",
@@ -24,10 +28,6 @@ const config: Config = {
         card: {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
-        },
-        accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
         },
       },
       backgroundImage: {


### PR DESCRIPTION
Adopt the exact Fumadocs color variables (HSL, neutral/monochrome):
- Light: background hsl(0 0% 96%), primary hsl(0 0% 9%), borders at 80%
- Dark: background hsl(0 0% 2%), primary hsl(0 0% 98%), borders at 14%
- Removed all violet/purple/cyan accent colors from every component
- gradient-text now uses neutral dark→light gray (matches fumadocs aesthetic)
- Skill bars, active tabs, buttons all use --primary (black/white)
- Code card window dots changed from colored to neutral border color

https://claude.ai/code/session_01QgsoMH86xWh95gnvpoWCrA